### PR TITLE
Revert "IMS: Remove API and constants related to ECT."

### DIFF
--- a/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
+++ b/ims/ims-ext-common/src/org/codeaurora/ims/utils/QtiImsExtUtils.java
@@ -76,6 +76,23 @@ public class QtiImsExtUtils {
     public static final String QTI_IMS_STATIC_IMAGE_SETTING =
             "ims_vt_call_static_image";
 
+    /* name for call transfer setting */
+    private static final String IMS_CALL_TRANSFER_SETTING = "ims_call_transfer";
+
+    /**
+     * Definitions for the call transfer type. For easier implementation,
+     * the transfer type is defined as a bit mask value.
+     */
+    //Value representing blind call transfer type
+    public static final int QTI_IMS_BLIND_TRANSFER = 0x01;
+    //Value representing assured call transfer type
+    public static final int QTI_IMS_ASSURED_TRANSFER = 0x02;
+    //Value representing consultative call transfer type
+    public static final int QTI_IMS_CONSULTATIVE_TRANSFER = 0x04;
+
+    /* Call transfer extra key */
+    public static final String QTI_IMS_TRANSFER_EXTRA_KEY = "transferType";
+
     /* Ims phoneId extra key */
     public static final String QTI_IMS_PHONE_ID_EXTRA_KEY = "phoneId";
 
@@ -370,6 +387,15 @@ public class QtiImsExtUtils {
      */
     public static boolean shallShowVideoQuality(int phoneId, Context context) {
         return isCarrierConfigEnabled(phoneId, context, QtiCarrierConfigs.SHOW_VIDEO_QUALITY_UI);
+    }
+
+    /***
+     * Checks if the IMS call transfer property is enabled or not.
+     * Returns true if enabled, or false otherwise.
+     */
+    public static boolean isCallTransferEnabled(Context context) {
+        return Settings.Global.getInt(context.getContentResolver(), IMS_CALL_TRANSFER_SETTING, 0)
+                == 1;
     }
 
    /**


### PR DESCRIPTION
This reverts commit da40ef630e655574019c4956851c5f318d2882e8.

Hello i open this pull request to fix an issue about calling over LTE
This commit has been merged on many roms as you can see here https://github.com/search?q=Revert+%22IMS%3A+Remove+API+and+constants+related+to+ECT.%22&type=commits

commit describition:
"Fixes userspace error when making call over LTE (VoLTE): E AndroidRuntime: java.lang.NoSuchMethodError: No static method isCallTransferEnabled(Landroid/content/Context;)Z in class Lorg/codeaurora/ims/utils/QtiImsExtUtils; or its super classes (declaration of 'org.codeaurora.ims.utils.QtiImsExtUtils' appears in /product/framework/ims-ext-common.jar)"
I indeed had this issue and fixed with this commit

Please to merge would help many devices
Thanks